### PR TITLE
Externalize config (SECRET_KEY and DEBUG)

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
+from decouple import config
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -20,10 +21,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'oro*o%-&4+#=g1jd^)-r=*h%@^qr14%87@t4y6f*@sat=5px-)'
+SECRET_KEY = config('SECRET_KEY', default="secret")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config('DEBUG', cast=bool)
 
 ALLOWED_HOSTS = []
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # Requirement packages
 Django >= 2.1.2
+python-decouple >= 3.1


### PR DESCRIPTION
Externalize configuration values (`SECRET_KEY` and `DEBUG`) in `setting.py` using `python-decouple`. Wait to merge into master.